### PR TITLE
add fields type "function" with an argument for more interaction;

### DIFF
--- a/dist/jquery.geocomplete.js
+++ b/dist/jquery.geocomplete.js
@@ -245,6 +245,18 @@ if (typeof google === "undefined" || typeof google.maps === "undefined" || typeo
           }
           _setFieldValue($field, addressType, placeDetails);
         }
+      } else if ($.type(fields) == "function") {
+          //console.log(placeDetails);
+          var address_components = placeDetails.address_components;
+          var components={};
+          jQuery.each(address_components, function(k,v1) {jQuery.each(v1.types, function(k2, v2){components[v2]=v1.short_name});});
+          components['formatted_address'] = placeDetails.formatted_address;
+          components['place_id'] = placeDetails.place_id;
+          components['url'] = placeDetails.url;
+          components['lat'] = placeDetails.geometry.location.lat();
+          components['lng'] = placeDetails.geometry.location.lng();
+          var execDynFunc = new Function(fields(components));
+          execDynFunc();
       }
       return $(this.element);
     };


### PR DESCRIPTION
not sure if that's helpful for someone else but I needed something more dynamic for the "field"  options and it was better than using onChange event.

usage : 
```
$("#userInput").geocomplete({ fields : function(results) {
       console.log(results);
} })
```

or  only specific value.
```
$("#userInput").geocomplete({ fields : function(results) {
       console.log(results.formatted_address);
} })
```

it's also possible to change the function dynamically, it prevents to initiate a new geocomplete : 

```
$("#userInput").data('gmap.geocomplete').fields = function(results) { 
      console.log(results.place_id);
}
``` 

the argument is results. Where result will contain all the information from : 
- address_components[] ( as number of field can change based on the location, all of them are returned ( short_name ));
- formatted_address
- place_id ( as id and reference are deprecated )
- lat ( from geometry.location)
- lng ( from geometry.location)
- url

"results" will have all the value as follow :
```
administrative_area_level_1:"PA"
administrative_area_level_2:"Montgomery County"
administrative_area_level_3:"Whitemarsh Township"
country:"US"
formatted_address:"416, 1100 E Hector St, Conshohocken, PA 19428, USA"
lat:40.07595389999999
lng:-75.28769849999998
locality:"Conshohocken"
place_id:"ChIJUx7p1Yy-xokRr97Ob9uGKp8"
political:"US"
postal_code:"19428"
route:"East Hector Street"
street_number:"1100"
url:"https://maps.google.com/q=416,+1100+E+Hector+St,+Conshohocken,+PA+19428,+USA&ftid=0x89c6be8cd5e91e53:0x9f2a86db6fcedeaf"
```

source for the "each" function to parse the "address_components"  https://stackoverflow.com/a/16429122/4167123 .

BR,
fas3r